### PR TITLE
JacksonModule configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,7 @@ ext {
        'commons-collections': 'org.apache.commons:commons-collections4:4.1',
        'jackson':         'com.fasterxml.jackson.core:jackson-databind:2.10.3',
        'jackson-anno':    'com.fasterxml.jackson.core:jackson-annotations:2.10.3',
+       'jackson-java8':   'com.fasterxml.jackson.module:jackson-module-parameter-names:2.10.3',
 	   
        'micrometer':      'io.micrometer:micrometer-core:1.4.1',
        'elastic-search': 'org.elasticsearch.client:elasticsearch-rest-client:7.6.1',

--- a/webserver-plugins/plugin-json-jackson/build.gradle
+++ b/webserver-plugins/plugin-json-jackson/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     compile deps['jackson']
     compile deps['jackson-anno']
+    compile deps['jackson-java8']
     
     //compile deps['commons-lang'] //used in json escaping BUT jackson is doing this actually..nm
     compile project(':webserver:http-router'), project(':http:http1_1-parser')

--- a/webserver-plugins/plugin-json-jackson/src/main/java/org/webpieces/plugin/json/JacksonModule.java
+++ b/webserver-plugins/plugin-json-jackson/src/main/java/org/webpieces/plugin/json/JacksonModule.java
@@ -2,11 +2,14 @@ package org.webpieces.plugin.json;
 
 import org.webpieces.router.api.extensions.BodyContentBinder;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
 
@@ -24,7 +27,9 @@ public class JacksonModule extends AbstractModule {
 	    uriBinder.addBinding().to(JacksonLookup.class);
 
 	    ObjectMapper mapper = new ObjectMapper()
-	    	.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+	    	.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+			.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+			.registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES));
 
 	    if(config.isConvertNullToEmptyStr()) {
 	        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);


### PR DESCRIPTION
Disable FAIL_ON_EMPTY_BEANS and by default use parameter names when constructing objects using constructors.